### PR TITLE
CDC-ACM Serial fix

### DIFF
--- a/Quark_Sketch/src/Makefile
+++ b/Quark_Sketch/src/Makefile
@@ -1,2 +1,2 @@
 obj-y += blink.o arduino/wiring_digital.o arduino/wiring_analog.o arduino/variant.o arduino/WInterrupts.o arduino/wiring.o arduino/serial_print.o sharedmemory_com.o
-#obj-y += smc.o arduino/wiring_digital.o arduino/wiring_analog.o arduino/variant.o arduino/WInterrupts.o arduino/wiring.o sharedmemory_com.o
+#obj-y += smc.o arduino/wiring_digital.o arduino/wiring_analog.o arduino/variant.o arduino/WInterrupts.o arduino/wiring.o arduino/serial_print.o sharedmemory_com.o

--- a/Quark_Sketch/src/smc.cpp
+++ b/Quark_Sketch/src/smc.cpp
@@ -67,9 +67,9 @@ struct gpio_callback cb;
 
 #define SOFTRESET_INTERRUPT_PIN		0
 
-#define ARCSTART_DELAY_CYCLES		6400000
-#define SERIAL_READ_TIMEOUT		1000
-
+#define ARCSTART_DELAY		500000	//500msec
+#define SERIAL_READ_TIMEOUT	1000
+#define CDCACM_TX_DELAY		4000
 
 // buffers
 static unsigned char data_buf[128];
@@ -97,7 +97,6 @@ void reboot();
 
 static void softReset_button_callback(struct device *port, struct gpio_callback *cb, uint32_t pins)
 {
-	PRINT("SOFT RESET\r\n");
 	reboot();
 }
 
@@ -134,8 +133,10 @@ static void write_data(struct device *dev, const char *buf, int len)
 	data_transmitted = false;
 	uart_fifo_fill(dev, (const uint8_t*)buf, len);
 	while (data_transmitted == false)
-		;
-
+	{
+		task_yield();
+	}
+	sys_thread_busy_wait(CDCACM_TX_DELAY); //allow enough time for the FIFO to be emptied
 	uart_irq_tx_disable(dev);
 }
 
@@ -147,13 +148,11 @@ void start_arc(unsigned int reset_vector)
 	}
 
 	curie_shared_data->flags = 0;
-	sys_thread_busy_wait(500000);
+	sys_thread_busy_wait(ARCSTART_DELAY);
 
 	*SCSS_SS_CFG_REG |= ARC_RUN_REQ_A;
 
-	sys_thread_busy_wait(500000);
-	
-	PRINT("ARC core started\n");
+	sys_thread_busy_wait(ARCSTART_DELAY);
 }
 
 void reboot(void)
@@ -187,14 +186,12 @@ void main(void)
 
 extern "C" void cdcacm_setup(void)
 {
-	PRINT("cdcacm_setup task\r\n");
 	uint32_t baudrate, dtr = 0;
 	int ret;
 
 
 	dev = device_get_binding(CONFIG_CDC_ACM_PORT_NAME);
 
-	PRINT("Wait for DTR\n");
 	while (1) {
 		uart_line_ctrl_get(dev, LINE_CTRL_DTR, &dtr);
 		if (dtr)
@@ -202,30 +199,20 @@ extern "C" void cdcacm_setup(void)
 		task_sleep(50);
 		task_yield();
 	}
-	
-	PRINT("DTR set, start test\n");
 
 	/* They are optional, we use them to test the interrupt endpoint */
 	ret = uart_line_ctrl_set(dev, LINE_CTRL_DCD, 1);
-	if (ret)
-		PRINT("Failed to set DCD, ret code %d\n", ret);
 	
 	acm_tx_state = ACM_TX_READY;
 	acm_rx_state = ACM_RX_READY;
 	curie_shared_data->cdc_acm_buffers_obj.host_open = true;
 	
 	ret = uart_line_ctrl_set(dev, LINE_CTRL_DSR, 1);
-	if (ret)
-		PRINT("Failed to set DSR, ret code %d\n", ret);
 
 	/* Wait 1 sec for the host to do all settings */
 	sys_thread_busy_wait(1000000);
 
 	ret = uart_line_ctrl_get(dev, LINE_CTRL_BAUD_RATE, &baudrate);
-	if (ret)
-		PRINT("Failed to get baudrate, ret code %d\n", ret);
-	else
-		PRINT("Baudrate detected: %d\n", baudrate);
 
 	uart_irq_callback_set(dev, interrupt_handler);
 		
@@ -239,7 +226,6 @@ extern "C" void cdcacm_setup(void)
 
 extern "C" void baudrate_reset(void)
 {
-	PRINT("baudrate_reset task\r\n");
 	uint32_t baudrate, ret = 0;
 	while(!usbSetupDone)
 	{
@@ -262,7 +248,6 @@ extern "C" void baudrate_reset(void)
 
 extern "C" void usb_serial(void)
 {
-	PRINT("usb_serial task\r\n");
 	while(!usbSetupDone)
 	{
 		task_yield();
@@ -286,14 +271,11 @@ extern "C" void quark_sketch(void)
 	//loop
 	while(1)
 	{
-		while(1)
+		for(int i = 0; i < smc_availableForRead(); i++)
 		{
-			for(int i = 0; i < smc_availableForRead(); i++)
-			{
-				smc_write(smc_read() * 2);
-			}
-			task_yield();
+			smc_write(smc_read() * 2);
 		}
+		task_yield();
 	}
 
 }
@@ -305,7 +287,6 @@ void softResetButton()
 	aon_gpio = device_get_binding("GPIO_AON_0");
 	if (!aon_gpio) 
 	{
-		PRINT("aon_gpio device not found.\n");
 		return;
 	}
 
@@ -359,7 +340,6 @@ void cdc_acm_rx()
 		if (!curie_shared_data->cdc_acm_buffers_obj.device_open) 
 		{
 			// ARC is not ready to receive this data - discard it
-			write_data(dev, "arc not ready\r\n", 15);
 			bytes_read = 0;
 			break;
 		}


### PR DESCRIPTION
-remove debug prints since it breaks Serial functionality when Serial1
is used in the ARC core
-add delay during transmission to allow FIFO to be properly emptied
-add blank example
