### PR TITLE
Change license header of SPI library

### DIFF
--- a/Quark_Sketch/src/arduino/libraries/SPI_LIB.cpp
+++ b/Quark_Sketch/src/arduino/libraries/SPI_LIB.cpp
@@ -1,20 +1,17 @@
 /*
- * Copyright (c) 2016 Intel Corporation.  All rights reserved.
+ * Copyright (c) 2016 Intel Corporation
  *
- * This library is free software; you can redistribute it and/or
- * modify it under the terms of the GNU Lesser General Public
- * License as published by the Free Software Foundation; either
- * version 2.1 of the License, or (at your option) any later version.
-
- * This library is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
- * Lesser General Public License for more details.
-
- * You should have received a copy of the GNU Lesser General Public
- * License along with this library; if not, write to the Free Software
- * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
  *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  */
 
 #include "SPI_LIB.h"
@@ -173,7 +170,6 @@ uint32_t SPIClass::transfer32(uint32_t data)
 	rbuff = (uint32_t*)rx_buffer;
 	return *rbuff;
 }
-// Preinstantiate Objects //////////////////////////////////////////////////////
 
 SPIClass SPI0 = SPIClass(0);
 SPIClass SPI1 = SPIClass(1);

--- a/Quark_Sketch/src/arduino/libraries/SPI_LIB.h
+++ b/Quark_Sketch/src/arduino/libraries/SPI_LIB.h
@@ -1,15 +1,17 @@
 /*
- * Copyright (c) 2010 by Cristian Maglie <c.maglie@arduino.cc>
- * Copyright (c) 2014 by Paul Stoffregen <paul@pjrc.com> (Transaction API)
- * Copyright (c) 2014 by Matthijs Kooijman <matthijs@stdin.nl> (SPISettings AVR)
- * Copyright (c) 2014 by Andrew J. Kroll <xxxajk@gmail.com> (atomicity fixes)
- * Copyright (c) 2016 by Intel Corporation <dino.tinitigan@intel.com (Curie ODK support)
- * SPI Master library for arduino.
+ * Copyright (c) 2016 Intel Corporation
  *
- * This file is free software; you can redistribute it and/or modify
- * it under the terms of either the GNU General Public License version 2
- * or the GNU Lesser General Public License version 2.1, both as
- * published by the Free Software Foundation.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  */
 
 #include <zephyr.h>


### PR DESCRIPTION
-change the license header of SPI library to the correct one which is
Apache 2.0
