### PR TITLE
Add task_yield() to CurieMailbox examples

### DIFF
--- a/CurieMailbox_SharedCounter/src/shared_counter.c
+++ b/CurieMailbox_SharedCounter/src/shared_counter.c
@@ -97,6 +97,8 @@ void quark_sketch(void)
             received = false;
             ipm_send(ipm, 1, 0, (uint32_t *)&val, sizeof(uint32_t));
         }
+
+        task_yield();
     }
 }
 

--- a/CurieMailbox_String/src/string.c
+++ b/CurieMailbox_String/src/string.c
@@ -80,6 +80,7 @@ void quark_sketch(void)
     while (1) {
         task_sleep(SLEEP_TIME);
         ipm_send(ipm, 1, 0, data, 16);
+        task_yield();
     }
 }
 


### PR DESCRIPTION
Since there are multiple tasks now (CDC-ACM, reset button etc), the
'quark_sketch' task needs to call task_yield() in order for the other
tasks to get some run-time. This allows USB and the soft reset button
to work properly when using the CurieMailbox examples.

@bigdinotech @SidLeung  please review
