### PR TITLE
arduino101_services/Makefile: compile 'arduino' directory

### DIFF
--- a/common/arduino101_services/Makefile
+++ b/common/arduino101_services/Makefile
@@ -1,1 +1,2 @@
+obj-y += arduino/
 obj-y += arduino101_services.o sharedmemory_com.o soc_ctrl.o cdcacm_serial.o


### PR DESCRIPTION
@bigdinotech please review. Needed for all x86 example apps to compile successfully.
