### PR TITLE
Keep x86 Arduino wrappers separate

### DIFF
--- a/Blank/src/main.c
+++ b/Blank/src/main.c
@@ -28,6 +28,9 @@
 
 void main (void)
 {
+    // Required for Arduino-like functionality on x86
+    variantInit();
+
 	//setup
 
 	//loop

--- a/Blink/src/blink.c
+++ b/Blink/src/blink.c
@@ -20,6 +20,9 @@
 
 void main (void)
 {
+    // Required for Arduino-like functionality on x86
+    variantInit();
+
 	//setup
 	int pin = 13;
 	pinMode(pin, OUTPUT);

--- a/PWM_Fade/src/pwm_fade.c
+++ b/PWM_Fade/src/pwm_fade.c
@@ -22,6 +22,9 @@ void main (void)
 {
 	//based on the Fade.ino example from Arduino
 
+    // Required for Arduino-like functionality on x86
+    variantInit();
+
 	//setup
 	int led = 6;           // the PWM pin the LED is attached to
 	int brightness = 0;    // how bright the LED is

--- a/PinInterrupts/src/pin_interrupts.c
+++ b/PinInterrupts/src/pin_interrupts.c
@@ -22,6 +22,9 @@ void togglePin();
 
 void main (void)
 {
+    // Required for Arduino-like functionality on x86
+    variantInit();
+
 	//setup
 	pinMode(12, INPUT);
 	attachInterrupt(12, togglePin, FALLING);

--- a/SMC/src/smc.c
+++ b/SMC/src/smc.c
@@ -20,6 +20,9 @@
 
 void main (void)
 {
+    // Required for Arduino-like functionality on x86
+    variantInit();
+
 	//setup
 
 	//loop

--- a/common/arduino101_services/Makefile
+++ b/common/arduino101_services/Makefile
@@ -1,2 +1,1 @@
-obj-y += arduino/
 obj-y += arduino101_services.o sharedmemory_com.o soc_ctrl.o cdcacm_serial.o

--- a/common/arduino101_services/arduino101_services.c
+++ b/common/arduino101_services/arduino101_services.c
@@ -16,7 +16,6 @@
 
 
 #include <zephyr.h>
-#include "arduino/arduino.h"
 #include "arduino101_services.h"
 
 #define SOFTRESET_INTERRUPT_PIN		0
@@ -53,7 +52,6 @@ void arduino101_services (void)
 	init_cdc_acm();
 	softResetButton();
 	init_sharedMemory_com();
-    variantInit();
 
 	// start ARC core
 	uint32_t *reset_vector;

--- a/create_symlinks.sh
+++ b/create_symlinks.sh
@@ -31,4 +31,3 @@ do
 done
 
 ln -s "$services_path" "$arduino_path"
-ln -s "$arduino_path" "$services_path"


### PR DESCRIPTION
'arduino101_services' is required for Arduino sketches to work correctly
on both cores. However, 'arduino' is only required if using the Arduino
wrappers for x86; keep them separate so that 'arduino101_services' can
be used without also including all of the x86 Arduino wrappers.

The downside to this approach is that a developer must now call `variantInit()` in their Zephyr application if they wish to use the Arduino wrappers.

@bigdinotech please review and test.

Steps for testing:

Install CODK-M as normal. Then, delete `x86-samples`, clone it again, and fetch the changes. Finally, run the `create_symlinks.sh` script (normally, the Makefile does this for you). Run the following shell commands to do it all;

```
rm -rf x86-samples
git clone https://github.com/01org/CODK-M-X86-Samples x86-samples
cd x86-samples
git fetch origin pull/25/head:new
git checkout new
./create_symlinks.sh
```
