### PR TITLE
Remove BOARD definition from example Makefiles

### DIFF
--- a/Blank/Makefile
+++ b/Blank/Makefile
@@ -1,4 +1,3 @@
-BOARD ?= arduino_101
 CONF_FILE = prj.conf
 
 include ${ZEPHYR_BASE}/Makefile.inc

--- a/Blink/Makefile
+++ b/Blink/Makefile
@@ -1,4 +1,3 @@
-BOARD ?= arduino_101
 CONF_FILE = prj.conf
 
 include ${ZEPHYR_BASE}/Makefile.inc

--- a/CurieMailbox_SharedCounter/Makefile
+++ b/CurieMailbox_SharedCounter/Makefile
@@ -1,4 +1,3 @@
-BOARD ?= arduino_101
 CONF_FILE = prj.conf
 
 include ${ZEPHYR_BASE}/Makefile.inc

--- a/CurieMailbox_String/Makefile
+++ b/CurieMailbox_String/Makefile
@@ -1,4 +1,3 @@
-BOARD ?= arduino_101
 CONF_FILE = prj.conf
 
 include ${ZEPHYR_BASE}/Makefile.inc

--- a/PWM_Fade/Makefile
+++ b/PWM_Fade/Makefile
@@ -1,4 +1,3 @@
-BOARD ?= arduino_101
 CONF_FILE = prj.conf
 
 include ${ZEPHYR_BASE}/Makefile.inc

--- a/PinInterrupts/Makefile
+++ b/PinInterrupts/Makefile
@@ -1,4 +1,3 @@
-BOARD ?= arduino_101
 CONF_FILE = prj.conf
 
 include ${ZEPHYR_BASE}/Makefile.inc

--- a/SMC/Makefile
+++ b/SMC/Makefile
@@ -1,4 +1,3 @@
-BOARD ?= arduino_101
 CONF_FILE = prj.conf
 
 include ${ZEPHYR_BASE}/Makefile.inc


### PR DESCRIPTION
These are already defined when building x86 and arc, in the
"compile-arc" and "compile-x86" targets in the main Makefile